### PR TITLE
Increase experiment corpus and refresh results

### DIFF
--- a/scripts/generate_keys.rb
+++ b/scripts/generate_keys.rb
@@ -6,7 +6,7 @@ require 'optparse'
 require 'time'
 
 options = {
-  count: 200,
+  count: 10_000,
   output: 'artifacts/keys.json',
   seed: 1337,
   prefix: 'user',


### PR DESCRIPTION
## Summary
- bump the deterministic key corpus used by the experiment harness to 10,000 keys
- refresh the README with updated dataset details and observed match rates from the rerun experiment

## Testing
- ./experiments/run_experiment.sh

------
https://chatgpt.com/codex/tasks/task_e_68d43ef62414832f87883b44d1bf0eca